### PR TITLE
fix: add puppeteer protocolTimeout BrowserConnectOptions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,11 @@ program
     'add puppeteer arguments ex: --sandbox',
     commaSeparatedList,
   )
+  .option(
+    '--protocolTimeout <timeout>',
+    'timeout setting for individual protocol calls in milliseconds',
+    commaSeparatedList,
+  )
 
   .action((options: GeneratePDFOptions) => {
     if (options.pdfFormat) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export interface GeneratePDFOptions {
   waitForRender: number;
   headerTemplate: string;
   footerTemplate: string;
+  protocolTimeout: number;
 }
 
 export async function generatePDF({
@@ -47,10 +48,12 @@ export async function generatePDF({
   waitForRender,
   headerTemplate,
   footerTemplate,
+  protocolTimeout,
 }: GeneratePDFOptions): Promise<void> {
   const browser = await puppeteer.launch({
     headless: 'new',
     args: puppeteerArgs,
+    protocolTimeout: protocolTimeout,
   });
   const page = await browser.newPage();
 


### PR DESCRIPTION
Add option `protocolTimeout` in puppeteer `BrowserConnectOptions` 
cf. https://pptr.dev/api/puppeteer.browserconnectoptions

-> Enable users to set their own protocolTimeout if the PDF is large and the scroll down exceed the default timeout (180_000 ms) 

