### PR TITLE
fix: fixed crash if details inside of tabs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,7 @@ export async function openDetails(
       );
       await (clickFunction
         ? clickFunction(summaryHandle)
-        : summaryHandle.click());
+        : summaryHandle.evaluate((sh) => sh.click()));
       await (waitFunction
         ? waitFunction(800)
         : new Promise((r) => setTimeout(r, 800)));


### PR DESCRIPTION
Fixes https://github.com/jean-humann/docs-to-pdf/issues/364

If `Details` was in a non default `TabItem`, then it was not accessible by puppeteer.
Changed the `.click()` to a click inside of an `.evaluate()`.
