### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ npx docs-to-pdf --initialDocURLs="https://docusaurus.io/docs/" --contentSelector
 
 ## Docusaurus Options
 
-| Option                 | Required | Description                                                                                                                                                                        |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--version`            | No       | Docusaurus version. Default is 2.                                                                                                                                                  |
-| `--builDir`            | No       | Path to Docusaurus build dir. Either absolute or relative from path of the shell                                                                                                   |
+| Option       | Required | Description                                                                                                                                                                        |
+|--------------| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--version`  | No       | Docusaurus version. Default is 2.                                                                                                                                                  |
+| `--buildDir` | No       | Path to Docusaurus build dir. Either absolute or relative from path of the shell                                                                                                   |
 
 ## 🎨 Examples and Demo PDF
 


### PR DESCRIPTION
`--builDir` -> `--buildDir`