### PR TITLE
ci(docker): optimize Docker CI matrix to test only Alpine Node 24

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,17 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - alpine
-          - debian
-        node-version:
-          - 20
-          - 22
-          - 24
         docusaurus-version:
           - v1
           - v2
           - v3
+        include:
+          - os: alpine
+            node-version: 24
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Reduced Docker CI test matrix from 18 combinations to just 3 combinations
- Now testing only Alpine Node 24 with all three Docusaurus versions (v1, v2, v3)
- Significantly speeds up CI pipeline while maintaining comprehensive Docusaurus version coverage

## Changes

**Before:**
- Matrix tested: 2 OS variants (alpine, debian) × 3 Node versions (20, 22, 24) × 3 Docusaurus versions (v1, v2, v3) = **18 test runs**

**After:**
- Matrix tests: Alpine Node 24 × 3 Docusaurus versions (v1, v2, v3) = **3 test runs**

## Rationale

- Alpine is the primary/recommended Docker image variant
- Node 24 is the latest LTS version we support
- Testing all Docusaurus versions ensures compatibility across major versions
- 83% reduction in CI time (18 → 3 jobs) while maintaining essential coverage

## Test plan

- [x] All tests pass locally
- [x] Linter passes
- [x] TypeScript builds successfully
- [ ] CI workflow executes successfully with new matrix configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)