### PR TITLE
ci: upload coverage reports for all Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
       - run: yarn test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.node-version == '24.x'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.node-version == '24.x' }}
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Updated the CI workflow to upload coverage reports and test results to Codecov for **all** Node.js versions (20.x, 22.x, 24.x) instead of only 24.x.

## Changes

- Removed the `if: matrix.node-version == '24.x'` condition from the Codecov upload step
- Updated the test results upload condition to run for all Node versions while still respecting cancellation

## Benefits

- More comprehensive coverage data across all supported Node.js versions
- Better visibility into version-specific code paths
- Aligns with the codecov.yml configuration that expects multiple uploads

## Test Plan

- [x] CI will run for all Node.js versions (20.x, 22.x, 24.x)
- [x] Each version will upload its coverage report
- [x] Codecov will merge the reports according to codecov.yml configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)