### PR TITLE
chore(deps): group puppeteer updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     open-pull-requests-limit: 15
     exclude-paths:
       - 'tests/website/**'
+    groups:
+      puppeteer:
+        patterns:
+          - "puppeteer*"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary

Updates Dependabot configuration to group `puppeteer` and `puppeteer-core` updates into a single PR instead of creating separate PRs for each package.

## Changes

- Added `groups` configuration to the npm package ecosystem
- Created `puppeteer` group with pattern matching `puppeteer*`
- This will now create one PR for both puppeteer and puppeteer-core updates

## Benefits

- Reduces PR noise
- Makes it easier to review related dependency updates together
- Both packages are tightly coupled and should be updated together

🤖 Generated with [Claude Code](https://claude.com/claude-code)