### PR TITLE
fix: skip clicking <details> elements that are already open

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -314,15 +314,23 @@ export async function openDetails(
   for (const detailsHandle of detailsHandles) {
     const summaryHandle = await detailsHandle.$('summary');
     if (summaryHandle) {
-      const summaryText = await summaryHandle.evaluate(
-        (node) => node.textContent,
-      );
-      await clickSummary(
-        summaryHandle,
-        summaryText,
-        clickFunction,
-        waitFunction,
-      );
+      const isOpen = await detailsHandle.evaluate((el) => el.open);
+      if (!isOpen) {
+        const summaryText = await summaryHandle.evaluate(
+          (node) => node.textContent,
+        );
+        await clickSummary(
+          summaryHandle,
+          summaryText,
+          clickFunction,
+          waitFunction,
+        );
+      } else {
+        const summaryText = await summaryHandle.evaluate(
+          (node) => node.textContent,
+        );
+        console.debug(`Skipping already-open details: ${summaryText}`);
+      }
     }
   }
 }

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -508,6 +508,28 @@ describeIfChrome('openDetails function', () => {
     expect(waitFunction).toHaveBeenCalledTimes(2);
     expect(waitFunction).toHaveBeenCalledWith(800);
   });
+
+  it('should skip details elements that are already open', async () => {
+    const clickFunction = jest.fn(async () => {});
+    const waitFunction = jest.fn(async () => {});
+
+    await page.setContent(`
+      <details open>
+        <summary>Already open</summary>
+        <div>Visible content</div>
+      </details>
+      <details>
+        <summary>Closed one</summary>
+        <div>Hidden content</div>
+      </details>
+    `);
+
+    await openDetails(page, clickFunction, waitFunction);
+
+    // Only the closed details element should be clicked
+    expect(clickFunction).toHaveBeenCalledTimes(1);
+    expect(waitFunction).toHaveBeenCalledTimes(1);
+  });
 });
 
 describeIfChrome('extractIframeContent function', () => {

--- a/tests/website/docs/faq.md
+++ b/tests/website/docs/faq.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+title: FAQ (Details Test)
+---
+
+# FAQ Page
+
+This page tests `<details>` elements in various states.
+
+## Already Open (default open)
+
+<details open>
+<summary>What is docs-to-pdf?</summary>
+
+A tool that generates PDFs from documentation websites like Docusaurus. This details element is **open by default** and should stay open during PDF generation.
+
+</details>
+
+<details open>
+<summary>How does it work?</summary>
+
+It uses Puppeteer to crawl pages, combine them into a single HTML document, and generate a PDF. This is also **open by default**.
+
+</details>
+
+## Closed by Default
+
+<details>
+<summary>How do I install it?</summary>
+
+```bash
+npm install -g docs-to-pdf
+```
+
+This details element is **closed by default** and should be opened during PDF generation.
+
+</details>
+
+<details>
+<summary>What options are available?</summary>
+
+Run `docs-to-pdf --help` to see all available options. This is also **closed by default**.
+
+</details>
+
+## Mixed Nesting
+
+<details open>
+<summary>Advanced Topics (open)</summary>
+
+This outer details is open by default.
+
+<details>
+<summary>Nested closed topic</summary>
+
+This nested details is closed and should be opened.
+
+</details>
+
+<details open>
+<summary>Nested open topic</summary>
+
+This nested details is already open and should stay open.
+
+</details>
+
+</details>


### PR DESCRIPTION
## Problem

`openDetails()` unconditionally clicks every `<summary>`, toggling—rather than opening—`<details>` elements. On sites where `<details>` elements have a default open state (common in Docusaurus FAQ components), this **closes** them before HTML capture, resulting in collapsed content in the PDF.

Fixes #580

## Fix

Check `el.open` before clicking. Only interact with `<details>` elements that are currently closed; already-open elements are skipped with a debug log.

## Changes

**`src/utils.ts`** — `openDetails()`:
- Added `detailsHandle.evaluate((el) => el.open)` check before clicking
- Already-open elements log `Skipping already-open details: <summary text>` at debug level

**`tests/utils.spec.ts`**:
- Added test case `should skip details elements that are already open` with mixed `<details open>` and closed `<details>` elements, asserting only closed ones are clicked

**`tests/website/docs/faq.md`**:
- Added FAQ test page with open, closed, and nested `<details>` elements for manual/E2E verification

## Verification

Tested against a local Docusaurus site with mixed open/closed `<details>`:

```
Found 7 elements of type details
Skipping already-open details: What is docs-to-pdf?
Skipping already-open details: How does it work?
Clicking summary: How do I install it?
Clicking summary: What options are available?
Skipping already-open details: Advanced Topics (open)
Clicking summary: Nested closed topic
Skipping already-open details: Nested open topic
```

All 111 tests pass, including the new test case.