### PR TITLE
ci: unblock pipeline and enable dependabot auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
+      - run: yarn lint
+      - run: yarn build
       - run: yarn test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,13 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip PRs that cannot mint an OIDC token / read the review secret:
+    # Dependabot runs and PRs from forks get a restricted GITHUB_TOKEN, so the
+    # review action can never authenticate there and would fail on every run,
+    # leaving the PR perpetually "unstable". Only run on same-repo, non-bot PRs.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -27,12 +29,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
+        # Advisory only: a review failure must not mark the PR as failing.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# Automatically enable auto-merge for Dependabot PRs once the required status
+# checks pass. Major version bumps are left for manual review.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+node = "22"
 yarn = "1.22.22"
 
 [env]


### PR DESCRIPTION
## Summary
Unblocks the CI pipeline and the stalled Dependabot backlog.

- **Claude review job**: skip on Dependabot/fork PRs (it cannot mint an OIDC token there, so it failed on every such PR and left them perpetually `UNSTABLE`); mark the review step `continue-on-error` so it is advisory only. Bump `actions/checkout` v4 → v5.
- **Dependabot auto-merge**: new workflow enabling `--auto --squash` for non-major dependency updates once required checks pass.
- **CI hardening**: run `yarn lint` and `yarn build` in `ci.yml` (previously only `yarn test`; type/lint errors were only caught by the bypassable pre-commit hook).
- **mise**: pin Node 22 (was unpinned; CI matrix floor is Node 20).

## Why
~19 Dependabot PRs were stuck: the only failing check on them was `claude-review` (cosmetic — not a required check), and no auto-merge was configured, so nothing merged automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)