### PR TITLE
fix: correct CLI option parsing and crawl edge cases

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -163,7 +163,7 @@ export function makeProgram() {
       .option(
         '--protocolTimeout <timeout>',
         'timeout setting for individual protocol calls in milliseconds',
-        commaSeparatedList,
+        (value) => Number.parseInt(value, 10),
       )
       .option('--filterKeyword <filterKeyword>', 'meta keyword to filter pages')
       .option(

--- a/src/provider/docusaurus.ts
+++ b/src/provider/docusaurus.ts
@@ -221,10 +221,12 @@ export async function generateFromBuild(
   );
 
   try {
-    const urlPath = new URL(options.initialDocURLs[0]).pathname;
-    options.initialDocURLs = [
-      `http://127.0.0.1:${serverInstance.port}${urlPath}`,
-    ];
+    // Remap every initial URL to the local server, preserving its path - not
+    // just the first one (previously the rest were silently dropped).
+    options.initialDocURLs = options.initialDocURLs.map(
+      (docUrl) =>
+        `http://127.0.0.1:${serverInstance.port}${new URL(docUrl).pathname}`,
+    );
     await generatePDF(options);
   } finally {
     // Always stop the server, even if PDF generation fails

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -487,9 +487,11 @@ export function generateToc(
   console.log(chalk.cyan('Start generating TOC...'));
   // Create TOC only for h1~h${maxLevel}
   // Regex to match all header tags
+  // `s` (dotAll) lets `.` match newlines so multi-line heading tags (common in
+  // Docusaurus v3 output, where attributes span several lines) are not skipped.
   const re = new RegExp(
     '<h[1-' + maxLevel + '](.+?)</h[1-' + maxLevel + ']( )*>',
-    'g',
+    'gs',
   );
   const modifiedContentHTML = contentHtml.replace(re, htmlReplacer);
 
@@ -579,7 +581,8 @@ export function replaceHeader(
   maxLevel = 3,
 ) {
   // Create a regular expression to match the header tags
-  const re = new RegExp('<h[1-' + maxLevel + '].*?>', 'g');
+  // `s` (dotAll) so multi-line opening tags (attributes across lines) match.
+  const re = new RegExp('<h[1-' + maxLevel + '].*?>', 'gs');
   // Replaces the ID attribute of the headers using regular expressions and the headerId parameter
   const modifiedContentHTML = matchedStr.replace(re, (header) => {
     if (header.match(/id( )*=( )*"/g)) {

--- a/tests/docusaurus.spec.ts
+++ b/tests/docusaurus.spec.ts
@@ -311,10 +311,14 @@ describe('generateFromBuild', () => {
       }),
     );
 
-    // Verify the URL path is preserved
+    // Verify every URL path is preserved (not just the first one)
     const callArgs = mockGeneratePDF.mock.calls[0][0];
+    expect(callArgs.initialDocURLs).toHaveLength(2);
     expect(callArgs.initialDocURLs[0]).toMatch(
       /http:\/\/127\.0\.0\.1:\d+\/docs\/intro/,
+    );
+    expect(callArgs.initialDocURLs[1]).toMatch(
+      /http:\/\/127\.0\.0\.1:\d+\/docs\/next/,
     );
 
     mockGeneratePDF.mockRestore();

--- a/tests/generateToc.test.ts
+++ b/tests/generateToc.test.ts
@@ -51,6 +51,24 @@ describe('generateToc', () => {
       expect(result.modifiedContentHTML).toBe(html);
       expect(result.tocHTML).toContain('toc-page');
     });
+
+    it('should match headings whose tags span multiple lines', () => {
+      // Docusaurus v3 emits opening heading tags with attributes across lines.
+      // Without the dotAll flag the regex skips these headings entirely.
+      const html = `
+        <h2
+          id="old-multiline"
+          class="anchor anchorWithStickyNavbar"
+        >
+          Multiline Heading
+        </h2>
+      `;
+
+      const result = generateToc(html);
+
+      expect(result.tocHTML).toContain('Multiline Heading');
+      expect(result.modifiedContentHTML).not.toContain('old-multiline');
+    });
   });
 
   describe('maxLevel option', () => {


### PR DESCRIPTION
## Summary
Three confirmed correctness bugs in PDF generation, each with a regression test.

- **`--protocolTimeout` parsed as the wrong type** (`src/command.ts`): it used `commaSeparatedList`, so a value like `30000` became `['30000']` and was passed to `puppeteer.launch({ protocolTimeout })` where a `number` is expected. Now parsed with `Number.parseInt`.
- **Multi-line heading tags skipped from the TOC** (`src/utils.ts`): the heading regexes lacked the `s` (dotAll) flag, so headings whose opening tag spans multiple lines (common in Docusaurus v3 output) were not matched — missing from the TOC and never assigned anchor IDs. Added `s` to both the TOC and `replaceHeader` regexes.
- **`generateFromBuild` dropped all but the first `initialDocURL`** (`src/provider/docusaurus.ts`): only `initialDocURLs[0]` was remapped to the local server. Now maps every URL.

## Tests
- `tests/generateToc.test.ts`: new case asserting a multi-line heading is included in the TOC and re-IDed (fails before the regex fix).
- `tests/docusaurus.spec.ts`: strengthened `generateFromBuild` to assert **both** URLs are remapped (fails before the fix).

`yarn lint`, `yarn build`, and the affected tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)