### PR TITLE
fix: redact basic-auth password in debug logging

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -90,7 +90,11 @@ export function makeProgram() {
     )
     .action((options: DocusaurusOptions) => {
       console.debug('Generate from Docusaurus');
-      console.debug(options);
+      // Redact the Basic Auth password so it is never written to logs/CI output.
+      console.debug({
+        ...options,
+        httpAuthPassword: options.httpAuthPassword ? '***' : undefined,
+      });
       handleCommandCompletion(generateDocusaurusPDF(options));
     });
 


### PR DESCRIPTION
The `docusaurus` command logged the full options object with `console.debug(options)`, printing `--httpAuthPassword` in clear text to stdout / CI logs. This redacts the password field before logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)