### PR TITLE
fix: restore CommonJS compatibility for ESM-only dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,15 @@ updates:
     open-pull-requests-limit: 15
     exclude-paths:
       - 'tests/website/**'
+    ignore:
+      # chalk v5+ is ESM-only; this package builds to CommonJS, so a major bump
+      # breaks CJS consumers with ERR_REQUIRE_ESM (see #562). Stay on v4.
+      - dependency-name: 'chalk'
+        update-type: 'version-update:semver-major'
     groups:
       puppeteer:
         patterns:
-          - "puppeteer*"
+          - 'puppeteer*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Jean Humann <jean.humann@gmail.com> (https://github.com/jean-humann)",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^5.6.2",
+    "chalk": "^4.1.2",
     "commander": "^14.0.1",
     "console-stamp": "^3.1.2",
     "express": "^5.1.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import console_stamp from 'console-stamp';
 import * as puppeteer from 'puppeteer-core';
-import { scrollPageToBottom } from 'puppeteer-autoscroll-down';
 import * as fs from 'fs-extra';
 import { chromeExecPath } from './browser';
 import * as utils from './utils';
@@ -241,8 +240,12 @@ export async function generatePDF(options: GeneratePDFOptions): Promise<void> {
     }
 
     // Scroll to the bottom of the page with puppeteer-autoscroll-down
-    // This forces lazy-loading images to load
+    // This forces lazy-loading images to load.
+    // Imported dynamically because puppeteer-autoscroll-down is ESM-only and this
+    // package builds to CommonJS - a static import would emit require() and throw
+    // ERR_REQUIRE_ESM on Node versions without require(ESM) support.
     console.log(chalk.cyan('Scroll to the bottom of the page...'));
+    const { scrollPageToBottom } = await import('puppeteer-autoscroll-down');
     await scrollPageToBottom(page, {}); //cast to puppeteer-core type
 
     // Generate PDF

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// The package builds to CommonJS, so its runtime dependencies must be
+// require()-able. ESM-only deps (e.g. chalk v5) silently break the published
+// CLI on Node versions without require(ESM) support (issue #562).
+//
+// `--no-experimental-require-module` forces the strict CommonJS behaviour on any
+// Node version, so a top-level require() of an ESM-only module throws
+// ERR_REQUIRE_ESM here even on Node >= 22 where it would otherwise be masked.
+const cliPath = path.join(__dirname, '..', 'lib', 'cli.js');
+
+// Only runs against the built output; skips if `yarn build` hasn't produced lib/.
+const describeIfBuilt = fs.existsSync(cliPath) ? describe : describe.skip;
+
+describeIfBuilt('built CommonJS CLI', () => {
+  test('loads under strict CommonJS and prints usage (guards against ESM-only deps)', () => {
+    const stdout = execFileSync(
+      process.execPath,
+      ['--no-experimental-require-module', cliPath, '--help'],
+      { encoding: 'utf8' },
+    );
+    expect(stdout).toContain('Usage: docs-to-pdf');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,7 +1862,7 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.3.0, chalk@^5.6.2:
+chalk@^5.3.0:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==


### PR DESCRIPTION
Fixes #562.

The package builds to **CommonJS** (`main: lib/cli.js`, no `"type":"module"`), but two runtime deps had become **ESM-only**, so the published CLI crashes with `ERR_REQUIRE_ESM` on Node versions without `require(ESM)` support (e.g. older Node 20). This was invisible in CI because `docker-ci` only exercised the CLI on Node 24 (where `require(ESM)` is enabled).

Reproduced deterministically with `node --no-experimental-require-module lib/cli.js --help` (forces strict CommonJS on any Node) → `ERR_REQUIRE_ESM` from `chalk`, then `puppeteer-autoscroll-down`.

### Fix
- **chalk** → pinned to `^4.1.2` (last CommonJS major). It's used pervasively in synchronous code, so a dynamic import is impractical. Dependabot now ignores chalk majors so it can't regress.
- **puppeteer-autoscroll-down** → imported dynamically (`await import(...)`) at its single async call site. `module: nodenext` preserves `import()` for ESM interop, so it stays on the current version while remaining require-safe.

### Test
- `tests/cli.spec.ts` loads the built CJS CLI under `--no-experimental-require-module` and asserts it prints usage — guarding against ESM-only deps slipping back in. Runs in the Node CI job (no Chrome needed) after `yarn build`.

Verified: `node --no-experimental-require-module lib/cli.js --help` (and `docusaurus --help`) now succeed; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)