### PR TITLE
ci: publish npm package with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # required for npm provenance attestation
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -26,7 +27,10 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish packages
-        run: yarn publish
+        # `npm publish --provenance` generates a signed provenance attestation
+        # via the workflow's OIDC token (id-token: write), linking the published
+        # package to this repo + commit. Works with the existing NPM_TOKEN.
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   publish-docker:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "docs-to-pdf",
   "version": "1.1.0",
   "description": "Generate PDF from Docusaurus",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jean-humann/docs-to-pdf.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jean-humann/docs-to-pdf/issues"
+  },
+  "homepage": "https://github.com/jean-humann/docs-to-pdf#readme",
   "main": "lib/cli.js",
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
Adds npm **provenance** to releases: `id-token: write` + `npm publish --provenance --access public` (replacing `yarn publish`). Releases will carry a signed attestation linking the package to this repo + commit, shown on npm.

- Works with the **existing `NPM_TOKEN`** — no npmjs.com config required.
- Inert until a release is published (`on: release: published`), so merging is safe.

**Left for your review (not auto-merged)** since it touches the publish pipeline. Validates only at actual release time.

Follow-up (your action, optional): migrate to npm **Trusted Publishing (OIDC)** on npmjs.com to drop the long-lived `NPM_TOKEN` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)