### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ name: Publish
 on:
   release:
     types: [published]
+  # Allow re-publishing the current version manually (e.g. if a release-time
+  # publish failed). Publishes whatever version is in package.json on the ref.
+  workflow_dispatch:
 
 jobs:
   publish-npm:
@@ -13,8 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      id-token: write # required for npm provenance attestation
+      id-token: write # OIDC token for npm Trusted Publishing + provenance
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -26,15 +28,18 @@ jobs:
         run: yarn
       - name: Build packages
         run: yarn build
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1; node 22 ships npm 10.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: Publish packages
-        # `npm publish --provenance` generates a signed provenance attestation
-        # via the workflow's OIDC token (id-token: write), linking the published
-        # package to this repo + commit. Works with the existing NPM_TOKEN.
+        # Authentication is via the GitHub OIDC token + the npm Trusted Publisher
+        # configured for this repo/workflow - no NPM_TOKEN needed. --provenance
+        # generates a signed attestation linking the package to this repo + commit.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   publish-docker:
     name: Publish docker images
+    # Only on real releases; manual workflow_dispatch re-publishes npm only.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Switches the npm publish from a long-lived `NPM_TOKEN` to **OIDC Trusted Publishing**, closing the supply-chain gap from the security review (and fixing the v1.2.0 publish, which failed because the token was no longer authorized).

- Drops `NODE_AUTH_TOKEN` + unused `packages: write` from `publish-npm`; auth is via the GitHub OIDC token + the npm Trusted Publisher.
- Upgrades npm to ≥ 11.5.1 (node 22 ships npm 10, which predates OIDC trusted-publishing support).
- Adds a `workflow_dispatch` trigger so a version can be re-published manually (e.g. to push v1.2.0 now); the Docker job stays release-only.
- Keeps `--provenance` (now signed via the same OIDC token).

**Requires** the npm Trusted Publisher to be configured first: `jean-humann/docs-to-pdf`, workflow `publish.yml`. Do not merge until that's set up, or a publish would fail with no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)