### PR TITLE
feat: avoid page breaks immediately after headings

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -233,6 +233,10 @@ export async function generatePDF(options: GeneratePDFOptions): Promise<void> {
       await utils.removeExcludeSelector(page, excludeSelectors);
     }
 
+    // Default print styles (e.g. keep headings with their following content),
+    // injected before user CSS so `--cssStyle` can override them.
+    await page.addStyleTag({ content: utils.DEFAULT_PDF_STYLESHEET });
+
     // Add CSS to HTML
     if (cssStyle) {
       console.log(chalk.cyan('Add CSS to HTML...'));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,21 @@ import sanitizeHtml from 'sanitize-html';
 console_stamp(console);
 
 /**
+ * Default print styles applied to every generated PDF, before any user
+ * `--cssStyle` (so they can be overridden).
+ *
+ * `break-after: avoid` keeps a heading attached to the content that follows it,
+ * so a heading is never left orphaned as the last thing on a page (#275).
+ * `break-inside: avoid` stops a heading from being split across two pages.
+ */
+export const DEFAULT_PDF_STYLESHEET = `
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid;
+    break-inside: avoid;
+  }
+`;
+
+/**
  * Helper function to create a delay promise
  * @param ms - milliseconds to wait
  * @returns Promise that resolves after the specified delay

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_PDF_STYLESHEET } from '../src/utils';
+
+describe('DEFAULT_PDF_STYLESHEET', () => {
+  it('targets all heading levels h1-h6', () => {
+    expect(DEFAULT_PDF_STYLESHEET).toMatch(/h1,\s*h2,\s*h3,\s*h4,\s*h5,\s*h6/);
+  });
+
+  it('keeps headings with the following content (avoids orphaned headings, #275)', () => {
+    expect(DEFAULT_PDF_STYLESHEET).toMatch(/break-after:\s*avoid/);
+  });
+
+  it('prevents a heading from being split across pages', () => {
+    expect(DEFAULT_PDF_STYLESHEET).toMatch(/break-inside:\s*avoid/);
+  });
+});


### PR DESCRIPTION
Fixes #275.

Injects a default print stylesheet before any user `--cssStyle`:
```css
h1, h2, h3, h4, h5, h6 { break-after: avoid; break-inside: avoid; }
```
so a heading is never left orphaned as the last thing on a page, and headings aren't split across pages. It's applied before `--cssStyle`, so users can still override it.

Unit test in `tests/styles.test.ts`; the rendered behaviour is exercised by the Docker e2e PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)