### PR TITLE
fix: restore CLI options dropped in the PDF outline refactor

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -39,8 +39,18 @@ export default {
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['lcov', 'text'],
 
-  // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  // Minimum global coverage. Deliberately conservative starting floors that sit
+  // well below the suite's actual coverage (browser-dependent suites only run
+  // where Chrome is available, e.g. CI/local, so the floor must clear the
+  // no-Chrome case too). Acts as a catastrophic-regression guard; raise over time.
+  coverageThreshold: {
+    global: {
+      statements: 55,
+      branches: 65,
+      functions: 45,
+      lines: 55,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -186,6 +186,18 @@ export function makeProgram() {
       .option(
         '--openDetail',
         'open details elements in the PDF, default is open',
+      )
+      .option(
+        '--extractIframes',
+        'extract and inline content from iframes (only same-origin or accessible iframes)',
+      )
+      .option(
+        '--httpAuthUser <username>',
+        'HTTP Basic Auth username for protected documentation sites',
+      )
+      .option(
+        '--httpAuthPassword <password>',
+        'HTTP Basic Auth password for protected documentation sites',
       );
   });
 

--- a/tests/command.spec.ts
+++ b/tests/command.spec.ts
@@ -1,0 +1,56 @@
+import {
+  commaSeparatedList,
+  generatePuppeteerPDFMargin,
+} from '../src/command/commander-options';
+import { makeProgram } from '../src/command/command';
+
+describe('commaSeparatedList', () => {
+  it('splits a comma-separated string into an array', () => {
+    expect(commaSeparatedList('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns a single-element array for one value', () => {
+    expect(commaSeparatedList('only')).toEqual(['only']);
+  });
+});
+
+describe('generatePuppeteerPDFMargin', () => {
+  it('maps four comma-separated values to top/right/bottom/left', () => {
+    expect(generatePuppeteerPDFMargin('1px,2px,3px,4px')).toEqual({
+      top: '1px',
+      right: '2px',
+      bottom: '3px',
+      left: '4px',
+    });
+  });
+});
+
+describe('makeProgram', () => {
+  const program = makeProgram();
+
+  it('is named docs-to-pdf', () => {
+    expect(program.name()).toBe('docs-to-pdf');
+  });
+
+  it('registers the docusaurus and core commands', () => {
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain('docusaurus');
+    expect(names).toContain('core');
+  });
+
+  it('parses --protocolTimeout as a number, not a list', () => {
+    const core = program.commands.find((c) => c.name() === 'core');
+    expect(core).toBeDefined();
+    const opt = core?.options.find((o) => o.long === '--protocolTimeout');
+    expect(opt).toBeDefined();
+    expect(opt?.parseArg?.('30000', undefined)).toBe(30000);
+  });
+
+  it('wires the HTTP basic-auth and iframe options (consumed by core.ts)', () => {
+    const core = program.commands.find((c) => c.name() === 'core');
+    const longs = core?.options.map((o) => o.long) ?? [];
+    expect(longs).toContain('--httpAuthUser');
+    expect(longs).toContain('--httpAuthPassword');
+    expect(longs).toContain('--extractIframes');
+  });
+});


### PR DESCRIPTION
While adding CLI tests (as planned), they immediately caught a **regression from #532**: the outline refactor was based on an older `command.ts` and dropped three options that `core.ts` still consumes, making them unreachable from the CLI:

- `--httpAuthUser` / `--httpAuthPassword` (HTTP basic auth for protected docs sites)
- `--extractIframes` (inline iframe content)

This restores the option registrations (verified: `docs-to-pdf core --help` now lists them again).

Also:
- Adds `tests/command.spec.ts` covering `commander-options` (100%) and `makeProgram` wiring, including a guard that `--protocolTimeout` parses to a **number** (the #593 fix). `command.ts` coverage 0% → ~76%.
- Re-enables a conservative global jest `coverageThreshold` (55/65/45/55) as a catastrophic-regression guard (suite runs ~89% with Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)