### PR TITLE
feat: add --excludeCoverPageHeaderFooter to omit header/footer on the cover page

### DIFF
--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -160,6 +160,10 @@ export function makeProgram() {
       .option('--headerTemplate <html>', 'html template for page header')
       .option('--footerTemplate <html>', 'html template for page footer')
       .option(
+        '--excludeCoverPageHeaderFooter',
+        'do not render the header/footer on the cover page',
+      )
+      .option(
         '--puppeteerArgs <selectors>',
         'add puppeteer arguments ex: --sandbox',
         commaSeparatedList,

--- a/src/core.ts
+++ b/src/core.ts
@@ -254,7 +254,7 @@ export async function generatePDF(options: GeneratePDFOptions): Promise<void> {
 
     // Generate PDF
     const pdf = new PDF(options);
-    await pdf.generate(page);
+    await pdf.generate(page, disableCover ? undefined : coverHTML);
   } finally {
     // Always close browser and cleanup temp directory, even if PDF generation fails
     await browser.close();

--- a/src/pdf/generate.ts
+++ b/src/pdf/generate.ts
@@ -23,6 +23,48 @@ export interface PDFOptions {
   pdfMargin: puppeteer.PDFOptions['margin'];
   headerTemplate: string;
   footerTemplate: string;
+  excludeCoverPageHeaderFooter?: boolean;
+}
+
+/**
+ * Replace the leading cover page(s) of a PDF with header/footer-free versions.
+ *
+ * Puppeteer's running header/footer are global to every page, so to omit them
+ * from the cover the cover is rendered a second time without them; this swaps
+ * the first `coverPdf.pageCount` pages of `fullPdf` for those cover pages.
+ * Because the cover content (and paper size/margin) is identical, the page
+ * count is preserved, so bookmark page destinations computed for the body stay
+ * valid.
+ *
+ * @param fullPdfBytes - the full document rendered with header/footer
+ * @param coverPdfBytes - the cover rendered without header/footer
+ * @returns the merged PDF bytes
+ */
+export async function swapLeadingCoverPages(
+  fullPdfBytes: Uint8Array,
+  coverPdfBytes: Uint8Array,
+): Promise<Uint8Array> {
+  const fullDoc = await PDFDocument.load(fullPdfBytes);
+  const coverDoc = await PDFDocument.load(coverPdfBytes);
+
+  const coverPageCount = Math.min(
+    coverDoc.getPageCount(),
+    fullDoc.getPageCount(),
+  );
+  const coverPages = await fullDoc.copyPages(
+    coverDoc,
+    coverDoc.getPageIndices().slice(0, coverPageCount),
+  );
+
+  // Remove the original (header/footer'd) cover pages, then insert the clean ones.
+  for (let i = coverPageCount - 1; i >= 0; i--) {
+    fullDoc.removePage(i);
+  }
+  coverPages.forEach((coverPage, index) =>
+    fullDoc.insertPage(index, coverPage),
+  );
+
+  return fullDoc.save();
 }
 
 export class PDF {
@@ -38,7 +80,10 @@ export class PDF {
    * @returns
    * @throws {Error} - if page.pdf() fails
    */
-  public async generate(page: puppeteer.Page): Promise<void> {
+  public async generate(
+    page: puppeteer.Page,
+    coverHtml?: string,
+  ): Promise<void> {
     console.log(chalk.cyan('Generate PDF...'));
 
     // Get page dimensions for coordinate mapping
@@ -105,7 +150,32 @@ export class PDF {
       console.error(chalk.red(err));
       throw err; // Re-throw original error to preserve stack trace
     });
-    const pdfDoc = await PDFDocument.load(pdf);
+
+    let pdfBytes: Uint8Array = pdf;
+
+    // Optionally omit the running header/footer from the cover page by
+    // re-rendering the cover on its own (without header/footer) and swapping it
+    // into the leading page(s). Only meaningful when a header/footer is shown.
+    if (
+      this.options.excludeCoverPageHeaderFooter &&
+      coverHtml &&
+      pdfExportOptions.displayHeaderFooter
+    ) {
+      console.log(chalk.cyan('Rendering cover page without header/footer...'));
+      await page.evaluate((html: string) => {
+        document.body.innerHTML = html;
+      }, coverHtml);
+      const coverPdf = await page.pdf({
+        ...pdfExportOptions,
+        path: undefined,
+        displayHeaderFooter: false,
+        headerTemplate: '',
+        footerTemplate: '',
+      });
+      pdfBytes = await swapLeadingCoverPages(pdf, coverPdf);
+    }
+
+    const pdfDoc = await PDFDocument.load(pdfBytes);
 
     // Get PDF page dimensions (first page, assuming all pages same size)
     const pdfPage = pdfDoc.getPage(0);

--- a/tests/command.spec.ts
+++ b/tests/command.spec.ts
@@ -53,4 +53,10 @@ describe('makeProgram', () => {
     expect(longs).toContain('--httpAuthPassword');
     expect(longs).toContain('--extractIframes');
   });
+
+  it('wires the --excludeCoverPageHeaderFooter option', () => {
+    const core = program.commands.find((c) => c.name() === 'core');
+    const longs = core?.options.map((o) => o.long) ?? [];
+    expect(longs).toContain('--excludeCoverPageHeaderFooter');
+  });
 });

--- a/tests/pdf_swap.spec.ts
+++ b/tests/pdf_swap.spec.ts
@@ -1,0 +1,59 @@
+import { PDFDocument, PageSizes } from 'pdf-lib';
+import { swapLeadingCoverPages } from '../src/pdf/generate';
+
+async function makePdf(sizes: Array<[number, number]>): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  for (const size of sizes) {
+    doc.addPage(size);
+  }
+  return doc.save();
+}
+
+describe('swapLeadingCoverPages', () => {
+  it('replaces a single leading cover page, preserving total page count', async () => {
+    // full = 3 A4 pages (with header/footer), cover = 1 A5 page (without)
+    const full = await makePdf([PageSizes.A4, PageSizes.A4, PageSizes.A4]);
+    const cover = await makePdf([PageSizes.A5]);
+
+    const doc = await PDFDocument.load(
+      await swapLeadingCoverPages(full, cover),
+    );
+
+    expect(doc.getPageCount()).toBe(3);
+    // page 0 is now the A5 cover; pages 1-2 remain A4 body pages
+    expect(Math.round(doc.getPage(0).getWidth())).toBe(
+      Math.round(PageSizes.A5[0]),
+    );
+    expect(Math.round(doc.getPage(1).getWidth())).toBe(
+      Math.round(PageSizes.A4[0]),
+    );
+    expect(Math.round(doc.getPage(2).getWidth())).toBe(
+      Math.round(PageSizes.A4[0]),
+    );
+  });
+
+  it('replaces multiple leading cover pages', async () => {
+    const full = await makePdf([
+      PageSizes.A5,
+      PageSizes.A5,
+      PageSizes.A4,
+      PageSizes.A4,
+    ]);
+    const cover = await makePdf([PageSizes.A3, PageSizes.A3]);
+
+    const doc = await PDFDocument.load(
+      await swapLeadingCoverPages(full, cover),
+    );
+
+    expect(doc.getPageCount()).toBe(4);
+    expect(Math.round(doc.getPage(0).getWidth())).toBe(
+      Math.round(PageSizes.A3[0]),
+    );
+    expect(Math.round(doc.getPage(1).getWidth())).toBe(
+      Math.round(PageSizes.A3[0]),
+    );
+    expect(Math.round(doc.getPage(2).getWidth())).toBe(
+      Math.round(PageSizes.A4[0]),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #582.

Puppeteer's running header/footer are global to every page. With the new opt-in `--excludeCoverPageHeaderFooter` flag, the cover is rendered a second time **without** header/footer and swapped into the leading page(s) of the document via pdf-lib. The cover content/paper size is identical, so **page count is preserved** and the #532 bookmark destinations stay valid.

- New `swapLeadingCoverPages()` helper (pure, unit-tested with distinct page sizes in `tests/pdf_swap.spec.ts`).
- `PDF.generate(page, coverHtml?)` does the second render only when the flag is set, a cover exists, and a header/footer is configured.
- Default off → zero change for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)