### PR TITLE
ci: keep commitlint on v20 for Node 20 compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
       # breaks CJS consumers with ERR_REQUIRE_ESM (see #562). Stay on v4.
       - dependency-name: 'chalk'
         update-type: 'version-update:semver-major'
+      # commitlint v21+ requires Node >= 22.12 and drops Node 20, which this
+      # project still supports (engines: >=20, CI tests 20.x). Stay on v20.
+      - dependency-name: 'commitlint'
+        update-type: 'version-update:semver-major'
+      - dependency-name: '@commitlint/*'
+        update-type: 'version-update:semver-major'
     groups:
       puppeteer:
         patterns:


### PR DESCRIPTION
commitlint v21 requires Node ≥22.12 and dropped Node 20, which this project still supports (`engines: >=20`, CI tests 20.x). PR #573 tried to bump `commitlint` to `^21.0.2`, which made `yarn install` fail on the Node-20 build job.

Since commitlint is a **dev-only** tool, this tells Dependabot to ignore `commitlint`/`@commitlint/*` **major** bumps so it stays on v20. Closing #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)